### PR TITLE
Extend golangci lint action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: v1.49
-
+        args: "-v --timeout 15m0s"


### PR DESCRIPTION
This commit extends the golangci lint action to 15 mins to prevent failure by timeout.